### PR TITLE
fix: Clarify configuration documentation for macvlan interfaces

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -59,8 +59,9 @@ config:
       type: string
       default: "f1"
       description: |
-        Name of the network interface handling communication over the F1 interface.
-        Host interface to use for the DU Network. If not specified, a bridge will be used.
+        Host interface to use for the F1 communication with the DU.
+        Used only in with the `macvlan` cni.
+        The corresponding macvlan interface needs to exist on the host.
     f1-ip-address:
       type: string
       default: "192.168.251.7/24"
@@ -73,8 +74,9 @@ config:
       type: string
       default: "n2"
       description: |
-        Name of the network interface handling communication over the N2 interface.
-        If not specified, a bridge will be used.
+        Host interface to use for the N2 communication with the AMF.
+        Used only in with the `macvlan` cni.
+        The corresponding macvlan interface needs to exist on the host.
     n2-ip-address:
       type: string
       default: "192.168.250.6/24"
@@ -83,8 +85,9 @@ config:
       type: string
       default: "n3"
       description: | 
-        Name of the network interface handling communication over the N3 interface. 
-        If not specified, a bridge will be used.
+        Host interface to use for the N3 communication with the UPF.
+        Used only in with the `macvlan` cni.
+        The corresponding macvlan interface needs to exist on the host.
     n3-ip-address:
       type: string
       default: "192.168.251.6/24"

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -60,8 +60,7 @@ config:
       default: "f1"
       description: |
         Host interface to use for the F1 communication with the DU.
-        Used only in with the `macvlan` cni.
-        The corresponding macvlan interface needs to exist on the host.
+        With the `macvlan` cni, the corresponding macvlan interface needs to exist on the host.
     f1-ip-address:
       type: string
       default: "192.168.251.7/24"
@@ -75,8 +74,7 @@ config:
       default: "n2"
       description: |
         Host interface to use for the N2 communication with the AMF.
-        Used only in with the `macvlan` cni.
-        The corresponding macvlan interface needs to exist on the host.
+        With the `macvlan` cni, the corresponding macvlan interface needs to exist on the host.
     n2-ip-address:
       type: string
       default: "192.168.250.6/24"
@@ -86,8 +84,7 @@ config:
       default: "n3"
       description: | 
         Host interface to use for the N3 communication with the UPF.
-        Used only in with the `macvlan` cni.
-        The corresponding macvlan interface needs to exist on the host.
+        With the `macvlan` cni, the corresponding macvlan interface needs to exist on the host.
     n3-ip-address:
       type: string
       default: "192.168.251.6/24"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -16,7 +16,7 @@ variable "app_name" {
 variable "channel" {
   description = "The channel to use when deploying a charm."
   type        = string
-  default     = "latest/edge"
+  default     = "2.1/edge"
 }
 
 variable "config" {


### PR DESCRIPTION
# Description

This clarifies the documentation of the interface names configuration items to reflect that they are only used for macvlan. (It is not entirely true, as the name is used for the config file and for the created interface in the container, but this is mostly inconsequential and should not be changed when using bridge mode.)

It also mentions that a matching macvlan host interface needs to be created first.

Also fixes the default channel in the Terraform module.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library