### PR TITLE
fix: Reorder checks for N2 relation later

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -119,7 +119,6 @@ async def _deploy_amf(ops_test: OpsTest):
     )
     await ops_test.model.integrate(relation1=AMF_CHARM_NAME, relation2=NRF_CHARM_NAME)
     await ops_test.model.integrate(relation1=AMF_CHARM_NAME, relation2=NMS_CHARM_NAME)
-    await ops_test.model.integrate(relation1=AMF_CHARM_NAME, relation2=DB_CHARM_NAME)
     await ops_test.model.integrate(relation1=AMF_CHARM_NAME, relation2=TLS_CHARM_NAME)
 
 


### PR DESCRIPTION
The N2 relation was previously checked early in the life cycle of the charm. It meant that not having a relation to an AMF would block the charm from doing some work that did not require that relation to be present, like patching the Kubernetes Statefulset, configuring Multus and providing the `fiveg_gnb_identity` data.

This last point can cause an issue where the CU starts and connects to an unconfigured AMF, because the network could not yet be configured by the NMS, because it did not have a GNB to configure.

This commit reorders the checks for N2 right before when it is required to solve this problem. It can also make the deployment faster, as it can make progress on the longer Kubernetes configuration in the background.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library