### PR TITLE
chore: use multus lib 0.16

### DIFF
--- a/tests/unit/test_charm_remove.py
+++ b/tests/unit/test_charm_remove.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+
+import scenario
+
+from tests.unit.fixtures import CUCharmFixtures
+
+
+class TestCharmRemove(CUCharmFixtures):
+    def test_given_unit_is_leader_when_remove_then_k8s_multus_is_removed(self):
+        container = scenario.Container(
+            name="cu",
+            can_connect=False,
+        )
+        state_in = scenario.State(leader=True, containers=[container])
+
+        self.ctx.run("remove", state_in)
+
+        self.mock_k8s_multus.remove.assert_called_once()


### PR DESCRIPTION
# Description

Use the latest multus library, simplifying how multus is managed. This new approach gets rid of the need of custom events. 

This PR depends on the lib PR being merged first:
- https://github.com/canonical/kubernetes-charm-libraries/pull/56

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library