### PR TITLE
fix: Adds F1 route when using bridge CNI

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -60,24 +60,24 @@ config:
       default: "f1"
       description: |
         Host interface to use for the F1 communication with the DU.
-        With the `macvlan` cni, the corresponding macvlan interface needs to exist on the host.
+        With the `macvlan` CNI, the corresponding macvlan interface needs to exist on the host.
     f1-ip-address:
       type: string
       default: "192.168.251.7/24"
       description: CU F1 interface IP Address
     f1-port:
       type: int
-      default: 2153
+      default: 2152
       description: Number of the port handling communication over the F1 interface.
     n3-interface-name:
       type: string
       default: "n3"
       description: | 
         Host interface to use for the N3 communication with the UPF.
-        With the `macvlan` cni, the corresponding macvlan interface needs to exist on the host.
+        With the `macvlan` CNI, the corresponding macvlan interface needs to exist on the host.
     n3-ip-address:
       type: string
-      default: "192.168.251.6/24"
+      default: "192.168.250.6/24"
       description: CU N3 interface IP Address in CIDR format
     n3-gateway-ip:
       type: string

--- a/src/charm.py
+++ b/src/charm.py
@@ -6,9 +6,9 @@
 
 import json
 import logging
-from ipaddress import IPv4Address
+from ipaddress import IPv4Address, ip_network
 from subprocess import check_output
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from charms.kubernetes_charm_libraries.v0.multus import (
     KubernetesMultusCharmLib,
@@ -30,7 +30,7 @@ from lightkube.models.meta_v1 import ObjectMeta
 from ops import ActiveStatus, BlockedStatus, CollectStatusEvent, WaitingStatus
 from ops.charm import CharmBase
 from ops.main import main
-from ops.pebble import Layer
+from ops.pebble import ExecError, Layer
 
 from charm_config import CharmConfig, CharmConfigInvalidError, CNIType
 from k8s_privileged import K8sPrivileged
@@ -42,7 +42,7 @@ CONFIG_FILE_NAME = "cu.conf"
 F1_RELATION_NAME = "fiveg_f1"
 N2_RELATION_NAME = "fiveg_n2"
 GNB_IDENTITY_RELATION_NAME = "fiveg_gnb_identity"
-DU_F1_DEFAULT_PORT = 2153
+DU_F1_DEFAULT_PORT = 2152
 WORKLOAD_VERSION_FILE_NAME = "/etc/workload-version"
 LOGGING_RELATION_NAME = "logging"
 
@@ -154,6 +154,10 @@ class OAIRANCUOperator(CharmBase):
             event.add_status(WaitingStatus("Waiting for N2 information"))
             logger.info("Waiting for N2 information")
             return
+        if self._charm_config.cni_type == CNIType.bridge and not self._f1_route_exists():
+            event.add_status(WaitingStatus("Waiting for the F1 route to be created"))
+            logger.info("Waiting for the F1 route to be created")
+            return
         event.add_status(ActiveStatus())
 
     def _configure(self, _) -> None:  # noqa C901
@@ -174,6 +178,8 @@ class OAIRANCUOperator(CharmBase):
             return
         if not self._k8s_privileged.is_patched(container_name=self._container_name):
             self._k8s_privileged.patch_statefulset(container_name=self._container_name)
+        if self._charm_config.cni_type == CNIType.bridge and not self._f1_route_exists():
+            self._create_f1_route()
         self._update_fiveg_f1_relation_data()
         self._update_fiveg_gnb_identity_relation_data()
 
@@ -192,6 +198,31 @@ class OAIRANCUOperator(CharmBase):
         if not self.unit.is_leader():
             return
         self._kubernetes_multus.remove()
+
+    def _f1_route_exists(self) -> bool:
+        """Return whether the specified route exist."""
+        try:
+            stdout, stderr = self._exec_command_in_workload_container(command="ip route show")
+        except ExecError as e:
+            logger.error("Failed retrieving routes: %s", e.stderr)
+            return False
+        f1_subnet = ip_network(self._charm_config.f1_ip_address, strict=False)
+        for line in stdout.splitlines():
+            if f"{f1_subnet} dev {self._charm_config.f1_interface_name}" in line:
+                return True
+        return False
+
+    def _create_f1_route(self) -> None:
+        """Create ip route for the F1 connectivity."""
+        try:
+            f1_subnet = ip_network(self._charm_config.f1_ip_address, strict=False)
+            self._exec_command_in_workload_container(
+                command=f"ip route replace {f1_subnet} dev {self._charm_config.f1_interface_name}"
+            )
+        except ExecError as e:
+            logger.error("Failed to create F1 route: %s", e.stderr)
+            return
+        logger.info("F1 route created")
 
     def _relation_created(self, relation_name: str) -> bool:
         """Return whether a given Juju relation was created.
@@ -401,6 +432,23 @@ class OAIRANCUOperator(CharmBase):
         self._f1_provider.set_f1_information(
             ip_address=f1_ip.split("/")[0], port=self._charm_config.f1_port
         )
+
+    def _exec_command_in_workload_container(
+        self, command: str, timeout: Optional[int] = 30, environment: Optional[dict] = None
+    ) -> Tuple[str, str | None]:
+        """Execute command in the workload container.
+
+        Args:
+            command: Command to execute
+            timeout: Timeout in seconds
+            environment: Environment Variables
+        """
+        process = self._container.exec(
+            command=command.split(),
+            timeout=timeout,
+            environment=environment,
+        )
+        return process.wait_output()
 
     @property
     def _gnb_name(self) -> str:

--- a/tests/unit/resources/expected_config.conf
+++ b/tests/unit/resources/expected_config.conf
@@ -24,9 +24,9 @@ gNBs =
         local_s_address  = "192.168.251.7";
         remote_s_address = "127.0.0.1";
         local_s_portc    = 501;
-        local_s_portd    = 2153;
+        local_s_portd    = 2152;
         remote_s_portc   = 500;
-        remote_s_portd   = 2153;
+        remote_s_portd   = 2152;
 
         SCTP :
         {
@@ -49,7 +49,7 @@ gNBs =
             GNB_INTERFACE_NAME_FOR_NG_AMF = "eth0";
             GNB_IPV4_ADDRESS_FOR_NG_AMF   = "1.1.1.1";
             GNB_INTERFACE_NAME_FOR_NGU    = "n3";
-            GNB_IPV4_ADDRESS_FOR_NGU      = "192.168.251.6";
+            GNB_IPV4_ADDRESS_FOR_NGU      = "192.168.250.6";
             GNB_PORT_FOR_S1U              = 2152;
         };
     }


### PR DESCRIPTION
# Description

When using `bridge` CNI for Multus, additional route is required to tell the workload which interface should be used for the F1 communication.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library