### PR TITLE
feat: Adds N3 router support

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -63,7 +63,7 @@ config:
         With the `macvlan` CNI, the corresponding macvlan interface needs to exist on the host.
     f1-ip-address:
       type: string
-      default: "192.168.251.7/24"
+      default: "192.168.254.7/24"
       description: CU F1 interface IP Address
     f1-port:
       type: int
@@ -77,15 +77,17 @@ config:
         With the `macvlan` CNI, the corresponding macvlan interface needs to exist on the host.
     n3-ip-address:
       type: string
-      default: "192.168.250.6/24"
+      default: "192.168.251.6/24"
       description: CU N3 interface IP Address in CIDR format
     n3-gateway-ip:
       type: string
+      default: "192.168.251.1"
       description: |
-        Gateway IP to the UPF's N3 interface. This should be provided if a route is required to UPF's N3 interface.
+        IP address of the Gateway towards the UPF.
     upf-subnet:
       type: string
-      description: UPF's N3 interface subnet. This should be provided if a route is required to UPF's N3 interface.
+      default: "192.168.252.0/24"
+      description: UPF's N3 interface subnet.
     mcc:
       type: string
       default: "001"

--- a/src/charm_config.py
+++ b/src/charm_config.py
@@ -54,13 +54,12 @@ class CUConfig(BaseModel):  # pylint: disable=too-few-public-methods
     model_config = ConfigDict(alias_generator=to_kebab, use_enum_values=True)
     cni_type: CNIType = CNIType.bridge
     f1_interface_name: StrictStr = Field(default="f1", min_length=1)
-    f1_ip_address: str = Field(default="192.168.251.7/24")
+    f1_ip_address: str = Field(default="192.168.254.7/24")
     f1_port: int = Field(ge=1, le=65535)
-    n2_interface_name: StrictStr = Field(default="eth0", min_length=1)
     n3_interface_name: StrictStr = Field(default="n3", min_length=1)
     n3_ip_address: str = Field(default="192.168.251.6/24")
-    n3_gateway_ip: IPv4Address = Field(default=None)
-    upf_subnet: IPvAnyNetwork = Field(default=None)
+    n3_gateway_ip: IPv4Address = Field(default="192.168.251.1")
+    upf_subnet: IPvAnyNetwork = Field(default="192.168.252.0/24")
     mcc: StrictStr = Field(pattern=r"^\d{3}$")
     mnc: StrictStr = Field(pattern=r"^\d{2}$")
     sst: int = Field(ge=1, le=4)
@@ -83,7 +82,6 @@ class CharmConfig:
         f1_interface_name: Name of the network interface used for F1 traffic
         f1_ip_address: IP address used by f1 interface
         f1_port: Number of the port used for F1 traffic
-        n2_interface_name: Name of the network interface used for N2 traffic
         n3_interface_name: Name of the network interface used for N3 traffic
         n3_ip_address: IP address used by n3 interface
         upf_subnet: Subnet for UPF n3 interface
@@ -98,7 +96,6 @@ class CharmConfig:
     f1_interface_name: StrictStr
     f1_ip_address: str
     f1_port: int
-    n2_interface_name: StrictStr
     n3_interface_name: StrictStr
     n3_ip_address: str
     upf_subnet: IPvAnyNetwork
@@ -118,7 +115,6 @@ class CharmConfig:
         self.f1_interface_name = cu_config.f1_interface_name
         self.f1_ip_address = cu_config.f1_ip_address
         self.f1_port = cu_config.f1_port
-        self.n2_interface_name = "eth0"
         self.n3_interface_name = cu_config.n3_interface_name
         self.n3_ip_address = cu_config.n3_ip_address
         self.upf_subnet = cu_config.upf_subnet

--- a/src/templates/cu.conf.j2
+++ b/src/templates/cu.conf.j2
@@ -46,7 +46,7 @@ gNBs =
 
         NETWORK_INTERFACES :
         {
-            GNB_INTERFACE_NAME_FOR_NG_AMF = "{{ cu_n2_interface_name }}";
+            GNB_INTERFACE_NAME_FOR_NG_AMF = "eth0";
             GNB_IPV4_ADDRESS_FOR_NG_AMF   = "{{ cu_n2_ip_address }}";
             GNB_INTERFACE_NAME_FOR_NGU    = "{{ cu_n3_interface_name }}";
             GNB_IPV4_ADDRESS_FOR_NGU      = "{{ cu_n3_ip_address }}";

--- a/tests/unit/resources/expected_config.conf
+++ b/tests/unit/resources/expected_config.conf
@@ -21,7 +21,7 @@ gNBs =
         nr_cellid        = 12345678L;
         tr_s_preference  = "f1";
         local_s_if_name  = "f1";
-        local_s_address  = "192.168.251.7";
+        local_s_address  = "192.168.254.7";
         remote_s_address = "127.0.0.1";
         local_s_portc    = 501;
         local_s_portd    = 2152;
@@ -49,7 +49,7 @@ gNBs =
             GNB_INTERFACE_NAME_FOR_NG_AMF = "eth0";
             GNB_IPV4_ADDRESS_FOR_NG_AMF   = "1.1.1.1";
             GNB_INTERFACE_NAME_FOR_NGU    = "n3";
-            GNB_IPV4_ADDRESS_FOR_NGU      = "192.168.250.6";
+            GNB_IPV4_ADDRESS_FOR_NGU      = "192.168.251.6";
             GNB_PORT_FOR_S1U              = 2152;
         };
     }

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -165,7 +165,7 @@ class TestCharmCollectStatus(CUCharmFixtures):
 
             assert state_out.unit_status == WaitingStatus("Waiting for N2 information")
 
-    def test_given_f1_route_is_missing_when_collect_unit_status_then_status_is_waiting(self):
+    def test_given_n3_route_is_missing_when_collect_unit_status_then_status_is_waiting(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             n2_relation = scenario.Relation(
                 endpoint="fiveg_n2",
@@ -200,7 +200,7 @@ class TestCharmCollectStatus(CUCharmFixtures):
 
             state_out = self.ctx.run("collect_unit_status", state_in)
 
-            assert state_out.unit_status == WaitingStatus("Waiting for the F1 route to be created")
+            assert state_out.unit_status == WaitingStatus("Waiting for the N3 route to be created")
 
     def test_given_all_status_check_are_ok_when_collect_unit_status_then_status_is_active(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -226,7 +226,7 @@ class TestCharmCollectStatus(CUCharmFixtures):
                 exec_mock={
                     ("ip", "route", "show"): scenario.ExecOutput(
                         return_code=0,
-                        stdout="192.168.251.0/24 dev f1 scope link",
+                        stdout="192.168.252.0/24 via 192.168.251.1",
                         stderr="",
                     ),
                 },

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -4,7 +4,6 @@
 
 import os
 import tempfile
-from ipaddress import ip_network
 
 import scenario
 from ops.pebble import Layer
@@ -37,7 +36,7 @@ class TestCharmConfigure(CUCharmFixtures):
                 exec_mock={
                     ("ip", "route", "show"): scenario.ExecOutput(
                         return_code=0,
-                        stdout="192.168.251.0/24 dev f1 scope link",
+                        stdout="192.168.252.0/24 via 192.168.251.1",
                         stderr="",
                     ),
                 },
@@ -78,7 +77,7 @@ class TestCharmConfigure(CUCharmFixtures):
                 exec_mock={
                     ("ip", "route", "show"): scenario.ExecOutput(
                         return_code=0,
-                        stdout="192.168.251.0/24 dev f1 scope link",
+                        stdout="192.168.252.0/24 via 192.168.251.1",
                         stderr="",
                     ),
                 },
@@ -119,7 +118,7 @@ class TestCharmConfigure(CUCharmFixtures):
                 exec_mock={
                     ("ip", "route", "show"): scenario.ExecOutput(
                         return_code=0,
-                        stdout="192.168.251.0/24 dev f1 scope link",
+                        stdout="192.168.252.0/24 via 192.168.251.1",
                         stderr="",
                     ),
                 },
@@ -165,7 +164,7 @@ class TestCharmConfigure(CUCharmFixtures):
                 exec_mock={
                     ("ip", "route", "show"): scenario.ExecOutput(
                         return_code=0,
-                        stdout="192.168.251.0/24 dev f1 scope link",
+                        stdout="192.168.252.0/24 via 192.168.251.1",
                         stderr="",
                     ),
                 },
@@ -214,7 +213,7 @@ class TestCharmConfigure(CUCharmFixtures):
                 exec_mock={
                     ("ip", "route", "show"): scenario.ExecOutput(
                         return_code=0,
-                        stdout="192.168.251.0/24 dev f1 scope link",
+                        stdout="192.168.252.0/24 via 192.168.251.1",
                         stderr="",
                     ),
                 },
@@ -271,7 +270,7 @@ class TestCharmConfigure(CUCharmFixtures):
                 exec_mock={
                     ("ip", "route", "show"): scenario.ExecOutput(
                         return_code=0,
-                        stdout="192.168.251.0/24 dev f1 scope link",
+                        stdout="192.168.252.0/24 via 192.168.251.1",
                         stderr="",
                     ),
                 },
@@ -321,7 +320,7 @@ class TestCharmConfigure(CUCharmFixtures):
                 exec_mock={
                     ("ip", "route", "show"): scenario.ExecOutput(
                         return_code=0,
-                        stdout="192.168.251.0/24 dev f1 scope link",
+                        stdout="192.168.252.0/24 via 192.168.251.1",
                         stderr="",
                     ),
                 },
@@ -338,7 +337,7 @@ class TestCharmConfigure(CUCharmFixtures):
             self.ctx.run("config_changed", state_in)
 
             self.mock_f1_set_information.assert_called_once_with(
-                ip_address="192.168.251.7",
+                ip_address="192.168.254.7",
                 port=2152,
             )
 
@@ -371,12 +370,7 @@ class TestCharmConfigure(CUCharmFixtures):
                 exec_mock={
                     ("ip", "route", "show"): scenario.ExecOutput(
                         return_code=0,
-                        stdout="192.168.251.0/24 dev f1 scope link",
-                        stderr="",
-                    ),
-                    ("ip", "route", "show"): scenario.ExecOutput(  # noqa: F601
-                        return_code=0,
-                        stdout=f"{ip_network(test_f1_ip_address, strict=False)} dev f1 scope link",
+                        stdout="192.168.252.0/24 via 192.168.251.1",
                         stderr="",
                     ),
                 },
@@ -398,7 +392,7 @@ class TestCharmConfigure(CUCharmFixtures):
                 port=3522,
             )
 
-    def test_given_f1_route_not_created_when_config_changed_then_f1_route_is_created(self, caplog):
+    def test_given_n3_route_not_created_when_config_changed_then_n3_route_is_created(self, caplog):
         with tempfile.TemporaryDirectory() as tmpdir:
             n2_relation = scenario.Relation(
                 endpoint="fiveg_n2",
@@ -431,9 +425,9 @@ class TestCharmConfigure(CUCharmFixtures):
                         "ip",
                         "route",
                         "replace",
-                        "192.168.251.0/24",
-                        "dev",
-                        "f1",
+                        "192.168.252.0/24",
+                        "via",
+                        "192.168.251.1",
                     ): scenario.ExecOutput(
                         return_code=0,
                         stdout="",
@@ -455,9 +449,9 @@ class TestCharmConfigure(CUCharmFixtures):
             # When scenario 7 is out, we should assert that the mock exec was called
             # instead of validating log content
             # Reference: https://github.com/canonical/ops-scenario/issues/180
-            assert "F1 route created" in caplog.text
+            assert "N3 route created" in caplog.text
 
-    def test_given_f1_route_created_when_config_changed_then_f1_route_is_not_created(self, caplog):
+    def test_given_n3_route_created_when_config_changed_then_n3_route_is_not_created(self, caplog):
         with tempfile.TemporaryDirectory() as tmpdir:
             n2_relation = scenario.Relation(
                 endpoint="fiveg_n2",
@@ -483,7 +477,7 @@ class TestCharmConfigure(CUCharmFixtures):
                 exec_mock={
                     ("ip", "route", "show"): scenario.ExecOutput(
                         return_code=0,
-                        stdout="192.168.251.0/24 dev f1 scope link",
+                        stdout="192.168.252.0/24 via 192.168.251.1",
                         stderr="",
                     ),
                 },
@@ -502,46 +496,4 @@ class TestCharmConfigure(CUCharmFixtures):
             # When scenario 7 is out, we should assert that the mock exec was called
             # instead of validating log content
             # Reference: https://github.com/canonical/ops-scenario/issues/180
-            assert "F1 route created" not in caplog.text
-
-    def test_given_cni_type_is_macvlan_when_config_changed_then_f1_route_is_not_created(self):
-        from unittest.mock import patch
-
-        patcher_exec = patch("ops.model.Container.exec")
-        mock_exec = patcher_exec.start()
-        with tempfile.TemporaryDirectory() as tmpdir:
-            n2_relation = scenario.Relation(
-                endpoint="fiveg_n2",
-                interface="fiveg_n2",
-                remote_app_data={
-                    "amf_hostname": "amf",
-                    "amf_port": "38412",
-                    "amf_ip_address": "1.2.3.4",
-                },
-            )
-            f1_relation = scenario.Relation(
-                endpoint="fiveg_f1",
-                interface="fiveg_f1",
-            )
-            config_mount = scenario.Mount(
-                location="/tmp/conf",
-                src=tmpdir,
-            )
-            container = scenario.Container(
-                name="cu",
-                mounts={"config": config_mount},
-                can_connect=True,
-            )
-            state_in = scenario.State(
-                model=scenario.Model(name="whatever"),
-                leader=True,
-                config={"cni-type": "macvlan"},
-                containers=[container],
-                relations=[n2_relation, f1_relation],
-            )
-            self.mock_k8s_privileged.is_patched.return_value = True
-            self.mock_check_output.return_value = b"1.1.1.1"
-
-            self.ctx.run("config_changed", state_in)
-
-            mock_exec.assert_not_called()
+            assert "N3 route created" not in caplog.text


### PR DESCRIPTION
# Description

In the field, the CU and the UPF are very likely to use different subnets. This PR implements support for the router facilitating the connectivity between the CU and the UPF over the N3 interface. 

List of changes:
- Adds N3 route creation
- Removes unnecessary F1 route
- Adds application name prefix to NADs and NetworkAnnotations to make sure they're unique
- Updates IP addressing to match the one used in Charmed Aether SD-Core

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library