### PR TITLE
fix: Allows using range of versions of the Terraform provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Deploy the charm.
 ```bash
 juju deploy oai-ran-cu-k8s --trust --channel=2.1/edge
 juju deploy sdcore-amf-k8s --trust --channel=1.5/edge
-juju integrate oai-ran-cu-k8s:fiveg_n2 sdcore-amf-k8s:fiveg_n2
+juju integrate oai-ran-cu-k8s:fiveg_n2 sdcore-amf-k8s:fiveg-n2
 ```
 
 ## Image

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.12.0"
+      version = ">= 0.12.0"
     }
   }
 }


### PR DESCRIPTION
# Description

- Fixes a problem with Juju Terraform provider versions incompatibility by allowing using anything >= 0.12.0
- Fixes AMF's `fiveg-n2` relation name in the README

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library