### PR TITLE
chore: use built-in testing from ops

### DIFF
--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -5,7 +5,7 @@
 from unittest.mock import patch
 
 import pytest
-import scenario
+from ops import testing
 
 from charm import OAIRANCUOperator
 
@@ -34,6 +34,6 @@ class CUCharmFixtures:
 
     @pytest.fixture(autouse=True)
     def context(self):
-        self.ctx = scenario.Context(
+        self.ctx = testing.Context(
             charm_type=OAIRANCUOperator,
         )

--- a/tests/unit/lib/charms/oai_ran_cu_k8s/v0/test_fiveg_f1_provider.py
+++ b/tests/unit/lib/charms/oai_ran_cu_k8s/v0/test_fiveg_f1_provider.py
@@ -4,8 +4,8 @@
 from unittest.mock import patch
 
 import pytest
-import scenario
 from charms.oai_ran_cu_k8s.v0.fiveg_f1 import FivegF1RequirerAvailableEvent
+from ops import testing
 
 from tests.unit.lib.charms.oai_ran_cu_k8s.v0.test_charms.test_provider_charm.src.charm import (
     WhateverCharm,
@@ -23,7 +23,7 @@ class TestFivegF1Provides:
 
     @pytest.fixture(autouse=True)
     def context(self):
-        self.ctx = scenario.Context(
+        self.ctx = testing.Context(
             charm_type=WhateverCharm,
             meta={
                 "name": "whatever-charm",
@@ -39,11 +39,11 @@ class TestFivegF1Provides:
     def test_given_valid_f1_interface_data_when_set_f1_information_then_f1_ip_address_and_port_are_pushed_to_the_relation_databag(  # noqa: E501
         self,
     ):
-        fiveg_f1_relation = scenario.Relation(
+        fiveg_f1_relation = testing.Relation(
             endpoint="fiveg_f1",
             interface="fiveg_f1",
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             relations=[fiveg_f1_relation],
             leader=True,
         )
@@ -59,11 +59,11 @@ class TestFivegF1Provides:
         assert relation.local_app_data["f1_port"] == "1234"
 
     def test_given_invalid_f1_ip_address_when_set_f1_information_then_error_is_raised(self):
-        fiveg_f1_relation = scenario.Relation(
+        fiveg_f1_relation = testing.Relation(
             endpoint="fiveg_f1",
             interface="fiveg_f1",
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             relations=[fiveg_f1_relation],
             leader=True,
         )
@@ -78,11 +78,11 @@ class TestFivegF1Provides:
         assert "Invalid relation data" in str(e.value)
 
     def test_given_invalid_f1_port_when_set_f1_information_then_error_is_raised(self):
-        fiveg_f1_relation = scenario.Relation(
+        fiveg_f1_relation = testing.Relation(
             endpoint="fiveg_f1",
             interface="fiveg_f1",
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             relations=[fiveg_f1_relation],
             leader=True,
         )
@@ -99,12 +99,12 @@ class TestFivegF1Provides:
     def test_given_fiveg_f1_relation_created_when_relation_changed_then_event_with_requirer_f1_port_is_emitted(  # noqa: E501
         self,
     ):
-        fiveg_f1_relation = scenario.Relation(
+        fiveg_f1_relation = testing.Relation(
             endpoint="fiveg_f1",
             interface="fiveg_f1",
             remote_app_data={"f1_ip_address": "1.2.3.4", "f1_port": "1234"},
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             relations=[fiveg_f1_relation],
             leader=True,
         )

--- a/tests/unit/lib/charms/oai_ran_cu_k8s/v0/test_fiveg_f1_requirer.py
+++ b/tests/unit/lib/charms/oai_ran_cu_k8s/v0/test_fiveg_f1_requirer.py
@@ -4,8 +4,8 @@
 from unittest.mock import patch
 
 import pytest
-import scenario
 from charms.oai_ran_cu_k8s.v0.fiveg_f1 import FivegF1ProviderAvailableEvent
+from ops import testing
 
 from tests.unit.lib.charms.oai_ran_cu_k8s.v0.test_charms.test_requirer_charm.src.charm import (
     WhateverCharm,
@@ -23,7 +23,7 @@ class TestFivegF1Requires:
 
     @pytest.fixture(autouse=True)
     def context(self):
-        self.ctx = scenario.Context(
+        self.ctx = testing.Context(
             charm_type=WhateverCharm,
             meta={
                 "name": "whatever-charm",
@@ -35,7 +35,7 @@ class TestFivegF1Requires:
     def test_given_fiveg_f1_relation_created_when_relation_changed_then_event_with_provider_f1_ip_address_and_port_is_emitted(  # noqa: E501
         self,
     ):
-        fiveg_f1_relation = scenario.Relation(
+        fiveg_f1_relation = testing.Relation(
             endpoint="fiveg_f1",
             interface="fiveg_f1",
             remote_app_data={
@@ -43,7 +43,7 @@ class TestFivegF1Requires:
                 "f1_port": "1234",
             },
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             relations=[fiveg_f1_relation],
             leader=True,
         )
@@ -58,11 +58,11 @@ class TestFivegF1Requires:
     def test_given_valid_f1_port_when_set_f1_information_then_requirer_f1_port_is_pushed_to_the_relation_databag(  # noqa: E501
         self,
     ):
-        fiveg_f1_relation = scenario.Relation(
+        fiveg_f1_relation = testing.Relation(
             endpoint="fiveg_f1",
             interface="fiveg_f1",
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             relations=[fiveg_f1_relation],
             leader=True,
         )
@@ -76,11 +76,11 @@ class TestFivegF1Requires:
         assert relation.local_app_data["f1_port"] == "1234"
 
     def test_given_invalid_f1_port_when_fiveg_f1_provider_available_then_error_is_raised(self):
-        fiveg_f1_relation = scenario.Relation(
+        fiveg_f1_relation = testing.Relation(
             endpoint="fiveg_f1",
             interface="fiveg_f1",
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             relations=[fiveg_f1_relation],
             leader=True,
         )

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -5,7 +5,7 @@
 import tempfile
 
 import pytest
-import scenario
+from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 
 from tests.unit.fixtures import CUCharmFixtures
@@ -13,7 +13,7 @@ from tests.unit.fixtures import CUCharmFixtures
 
 class TestCharmCollectStatus(CUCharmFixtures):
     def test_given_unit_is_not_leader_when_collect_unit_status_then_status_is_blocked(self):
-        state_in = scenario.State(leader=False)
+        state_in = testing.State(leader=False)
 
         state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
 
@@ -38,7 +38,7 @@ class TestCharmCollectStatus(CUCharmFixtures):
     def test_given_invalid_config_when_collect_unit_status_then_status_is_blocked(
         self, config_param, value
     ):
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             config={
                 config_param: value,
@@ -55,16 +55,16 @@ class TestCharmCollectStatus(CUCharmFixtures):
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_k8s_privileged.is_patched.return_value = True
             self.mock_check_output.return_value = b"1.1.1.1"
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 source=temp_dir,
                 location="/tmp/conf",
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="cu",
                 can_connect=True,
                 mounts={"config": config_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 config={},
                 containers=[container],
@@ -77,12 +77,12 @@ class TestCharmCollectStatus(CUCharmFixtures):
     def test_given_workload_container_cant_be_connected_to_when_collect_unit_status_then_status_is_waiting(  # noqa: E501
         self,
     ):
-        n2_relation = scenario.Relation(endpoint="fiveg_n2", interface="fiveg_n2")
-        container = scenario.Container(
+        n2_relation = testing.Relation(endpoint="fiveg_n2", interface="fiveg_n2")
+        container = testing.Container(
             name="cu",
             can_connect=False,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True, config={}, relations=[n2_relation], containers=[container]
         )
 
@@ -93,13 +93,13 @@ class TestCharmCollectStatus(CUCharmFixtures):
     def test_given_pod_ip_is_not_available_when_collect_unit_status_then_status_is_waiting(  # noqa: E501
         self,
     ):
-        n2_relation = scenario.Relation(endpoint="fiveg_n2", interface="fiveg_n2")
-        container = scenario.Container(
+        n2_relation = testing.Relation(endpoint="fiveg_n2", interface="fiveg_n2")
+        container = testing.Container(
             name="cu",
             can_connect=True,
         )
         self.mock_check_output.return_value = b""
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True, config={}, relations=[n2_relation], containers=[container]
         )
 
@@ -110,14 +110,14 @@ class TestCharmCollectStatus(CUCharmFixtures):
     def test_given_charm_statefulset_is_not_patched_when_collect_unit_status_then_status_is_waiting(  # noqa: E501
         self,
     ):
-        n2_relation = scenario.Relation(endpoint="fiveg_n2", interface="fiveg_n2")
+        n2_relation = testing.Relation(endpoint="fiveg_n2", interface="fiveg_n2")
         self.mock_k8s_privileged.is_patched.return_value = False
         self.mock_check_output.return_value = b"1.1.1.1"
-        container = scenario.Container(
+        container = testing.Container(
             name="cu",
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True, config={}, relations=[n2_relation], containers=[container]
         )
 
@@ -126,14 +126,14 @@ class TestCharmCollectStatus(CUCharmFixtures):
         assert state_out.unit_status == WaitingStatus("Waiting for statefulset to be patched")
 
     def test_give_storage_is_not_attached_when_collect_unit_status_then_status_is_waiting(self):
-        n2_relation = scenario.Relation(endpoint="fiveg_n2", interface="fiveg_n2")
+        n2_relation = testing.Relation(endpoint="fiveg_n2", interface="fiveg_n2")
         self.mock_k8s_privileged.is_patched.return_value = True
         self.mock_check_output.return_value = b"1.1.1.1"
-        container = scenario.Container(
+        container = testing.Container(
             name="cu",
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True, config={}, relations=[n2_relation], containers=[container]
         )
 
@@ -145,19 +145,19 @@ class TestCharmCollectStatus(CUCharmFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
-            n2_relation = scenario.Relation(endpoint="fiveg_n2", interface="fiveg_n2")
+            n2_relation = testing.Relation(endpoint="fiveg_n2", interface="fiveg_n2")
             self.mock_k8s_privileged.is_patched.return_value = True
             self.mock_check_output.return_value = b"1.1.1.1"
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 source=temp_dir,
                 location="/tmp/conf",
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="cu",
                 can_connect=True,
                 mounts={"config": config_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True, config={}, relations=[n2_relation], containers=[container]
             )
 
@@ -167,7 +167,7 @@ class TestCharmCollectStatus(CUCharmFixtures):
 
     def test_given_n3_route_is_missing_when_collect_unit_status_then_status_is_waiting(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            n2_relation = scenario.Relation(
+            n2_relation = testing.Relation(
                 endpoint="fiveg_n2",
                 interface="fiveg_n2",
                 remote_app_data={
@@ -178,23 +178,23 @@ class TestCharmCollectStatus(CUCharmFixtures):
             )
             self.mock_k8s_privileged.is_patched.return_value = True
             self.mock_check_output.return_value = b"1.1.1.1"
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 source=temp_dir,
                 location="/tmp/conf",
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="cu",
                 can_connect=True,
                 mounts={"config": config_mount},
                 execs={
-                    scenario.Exec(
+                    testing.Exec(
                         command_prefix=["ip", "route", "show"],
                         stdout="",
                         stderr="",
                     )
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True, config={}, relations=[n2_relation], containers=[container]
             )
 
@@ -204,7 +204,7 @@ class TestCharmCollectStatus(CUCharmFixtures):
 
     def test_given_all_status_check_are_ok_when_collect_unit_status_then_status_is_active(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            n2_relation = scenario.Relation(
+            n2_relation = testing.Relation(
                 endpoint="fiveg_n2",
                 interface="fiveg_n2",
                 remote_app_data={
@@ -215,23 +215,23 @@ class TestCharmCollectStatus(CUCharmFixtures):
             )
             self.mock_k8s_privileged.is_patched.return_value = True
             self.mock_check_output.return_value = b"1.1.1.1"
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 source=temp_dir,
                 location="/tmp/conf",
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="cu",
                 can_connect=True,
                 mounts={"config": config_mount},
                 execs={
-                    scenario.Exec(
+                    testing.Exec(
                         command_prefix=["ip", "route", "show"],
                         stdout="192.168.252.0/24 via 192.168.251.1",
                         stderr="",
                     )
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True, config={}, relations=[n2_relation], containers=[container]
             )
 
@@ -241,7 +241,7 @@ class TestCharmCollectStatus(CUCharmFixtures):
 
     def test_given_multus_disabled_when_collect_status_then_status_is_blocked(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            n2_relation = scenario.Relation(
+            n2_relation = testing.Relation(
                 endpoint="fiveg_n2",
                 interface="fiveg_n2",
                 remote_app_data={
@@ -252,16 +252,16 @@ class TestCharmCollectStatus(CUCharmFixtures):
             )
             self.mock_k8s_privileged.is_patched.return_value = True
             self.mock_check_output.return_value = b"1.1.1.1"
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 source=temp_dir,
                 location="/tmp/conf",
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="cu",
                 can_connect=True,
                 mounts={"config": config_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True, config={}, relations=[n2_relation], containers=[container]
             )
             self.mock_k8s_multus.multus_is_available.return_value = False
@@ -274,7 +274,7 @@ class TestCharmCollectStatus(CUCharmFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
-            n2_relation = scenario.Relation(
+            n2_relation = testing.Relation(
                 endpoint="fiveg_n2",
                 interface="fiveg_n2",
                 remote_app_data={
@@ -285,16 +285,16 @@ class TestCharmCollectStatus(CUCharmFixtures):
             )
             self.mock_k8s_privileged.is_patched.return_value = True
             self.mock_check_output.return_value = b"1.1.1.1"
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 source=temp_dir,
                 location="/tmp/conf",
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="cu",
                 can_connect=True,
                 mounts={"config": config_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True, config={}, relations=[n2_relation], containers=[container]
             )
             self.mock_k8s_multus.multus_is_available.return_value = True

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -5,7 +5,7 @@
 import os
 import tempfile
 
-import scenario
+from ops import testing
 from ops.pebble import Layer
 
 from tests.unit.fixtures import CUCharmFixtures
@@ -16,7 +16,7 @@ class TestCharmConfigure(CUCharmFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tmpdir:
-            n2_relation = scenario.Relation(
+            n2_relation = testing.Relation(
                 endpoint="fiveg_n2",
                 interface="fiveg_n2",
                 remote_app_data={
@@ -25,23 +25,23 @@ class TestCharmConfigure(CUCharmFixtures):
                     "amf_ip_address": "1.2.3.4",
                 },
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/tmp/conf",
                 source=tmpdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="cu",
                 mounts={"config": config_mount},
                 can_connect=True,
                 execs={
-                    scenario.Exec(
+                    testing.Exec(
                         command_prefix=["ip", "route", "show"],
                         stdout="192.168.252.0/24 via 192.168.251.1",
                         stderr="",
                     )
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 containers=[container],
                 relations=[n2_relation],
@@ -57,7 +57,7 @@ class TestCharmConfigure(CUCharmFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tmpdir:
-            n2_relation = scenario.Relation(
+            n2_relation = testing.Relation(
                 endpoint="fiveg_n2",
                 interface="fiveg_n2",
                 remote_app_data={
@@ -66,23 +66,23 @@ class TestCharmConfigure(CUCharmFixtures):
                     "amf_ip_address": "1.2.3.4",
                 },
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/tmp/conf",
                 source=tmpdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="cu",
                 mounts={"config": config_mount},
                 can_connect=True,
                 execs={
-                    scenario.Exec(
+                    testing.Exec(
                         command_prefix=["ip", "route", "show"],
                         stdout="192.168.252.0/24 via 192.168.251.1",
                         stderr="",
                     )
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 containers=[container],
                 relations=[n2_relation],
@@ -98,7 +98,7 @@ class TestCharmConfigure(CUCharmFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tmpdir:
-            n2_relation = scenario.Relation(
+            n2_relation = testing.Relation(
                 endpoint="fiveg_n2",
                 interface="fiveg_n2",
                 remote_app_data={
@@ -107,24 +107,24 @@ class TestCharmConfigure(CUCharmFixtures):
                     "amf_ip_address": "1.2.3.4",
                 },
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/tmp/conf",
                 source=tmpdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="cu",
                 mounts={"config": config_mount},
                 can_connect=True,
                 execs={
-                    scenario.Exec(
+                    testing.Exec(
                         command_prefix=["ip", "route", "show"],
                         stdout="192.168.252.0/24 via 192.168.251.1",
                         stderr="",
                     )
                 },
             )
-            state_in = scenario.State(
-                model=scenario.Model(name="whatever"),
+            state_in = testing.State(
+                model=testing.Model(name="whatever"),
                 leader=True,
                 containers=[container],
                 relations=[n2_relation],
@@ -144,7 +144,7 @@ class TestCharmConfigure(CUCharmFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tmpdir:
-            n2_relation = scenario.Relation(
+            n2_relation = testing.Relation(
                 endpoint="fiveg_n2",
                 interface="fiveg_n2",
                 remote_app_data={
@@ -153,24 +153,24 @@ class TestCharmConfigure(CUCharmFixtures):
                     "amf_ip_address": "1.2.3.4",
                 },
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/tmp/conf",
                 source=tmpdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="cu",
                 mounts={"config": config_mount},
                 can_connect=True,
                 execs={
-                    scenario.Exec(
+                    testing.Exec(
                         command_prefix=["ip", "route", "show"],
                         stdout="192.168.252.0/24 via 192.168.251.1",
                         stderr="",
                     )
                 },
             )
-            state_in = scenario.State(
-                model=scenario.Model(name="whatever"),
+            state_in = testing.State(
+                model=testing.Model(name="whatever"),
                 leader=True,
                 containers=[container],
                 relations=[n2_relation],
@@ -193,7 +193,7 @@ class TestCharmConfigure(CUCharmFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tmpdir:
-            n2_relation = scenario.Relation(
+            n2_relation = testing.Relation(
                 endpoint="fiveg_n2",
                 interface="fiveg_n2",
                 remote_app_data={
@@ -202,24 +202,24 @@ class TestCharmConfigure(CUCharmFixtures):
                     "amf_ip_address": "1.2.3.4",
                 },
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/tmp/conf",
                 source=tmpdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="cu",
                 mounts={"config": config_mount},
                 can_connect=True,
                 execs={
-                    scenario.Exec(
+                    testing.Exec(
                         command_prefix=["ip", "route", "show"],
                         stdout="192.168.252.0/24 via 192.168.251.1",
                         stderr="",
                     )
                 },
             )
-            state_in = scenario.State(
-                model=scenario.Model(name="whatever"),
+            state_in = testing.State(
+                model=testing.Model(name="whatever"),
                 leader=True,
                 containers=[container],
                 relations=[n2_relation],
@@ -247,7 +247,7 @@ class TestCharmConfigure(CUCharmFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tmpdir:
-            n2_relation = scenario.Relation(
+            n2_relation = testing.Relation(
                 endpoint="fiveg_n2",
                 interface="fiveg_n2",
                 remote_app_data={
@@ -256,28 +256,28 @@ class TestCharmConfigure(CUCharmFixtures):
                     "amf_ip_address": "1.2.3.4",
                 },
             )
-            fiveg_gnb_relation = scenario.Relation(
+            fiveg_gnb_relation = testing.Relation(
                 endpoint="fiveg_gnb_identity",
                 interface="fiveg_gnb_identity",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/tmp/conf",
                 source=tmpdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="cu",
                 mounts={"config": config_mount},
                 can_connect=True,
                 execs={
-                    scenario.Exec(
+                    testing.Exec(
                         command_prefix=["ip", "route", "show"],
                         stdout="192.168.252.0/24 via 192.168.251.1",
                         stderr="",
                     )
                 },
             )
-            state_in = scenario.State(
-                model=scenario.Model(name="whatever"),
+            state_in = testing.State(
+                model=testing.Model(name="whatever"),
                 leader=True,
                 containers=[container],
                 relations=[n2_relation, fiveg_gnb_relation],
@@ -297,7 +297,7 @@ class TestCharmConfigure(CUCharmFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tmpdir:
-            n2_relation = scenario.Relation(
+            n2_relation = testing.Relation(
                 endpoint="fiveg_n2",
                 interface="fiveg_n2",
                 remote_app_data={
@@ -306,28 +306,28 @@ class TestCharmConfigure(CUCharmFixtures):
                     "amf_ip_address": "1.2.3.4",
                 },
             )
-            f1_relation = scenario.Relation(
+            f1_relation = testing.Relation(
                 endpoint="fiveg_f1",
                 interface="fiveg_f1",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/tmp/conf",
                 source=tmpdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="cu",
                 mounts={"config": config_mount},
                 can_connect=True,
                 execs={
-                    scenario.Exec(
+                    testing.Exec(
                         command_prefix=["ip", "route", "show"],
                         stdout="192.168.252.0/24 via 192.168.251.1",
                         stderr="",
                     )
                 },
             )
-            state_in = scenario.State(
-                model=scenario.Model(name="whatever"),
+            state_in = testing.State(
+                model=testing.Model(name="whatever"),
                 leader=True,
                 containers=[container],
                 relations=[n2_relation, f1_relation],
@@ -347,7 +347,7 @@ class TestCharmConfigure(CUCharmFixtures):
     ):
         test_f1_ip_address = "10.3.5.1/24"
         with tempfile.TemporaryDirectory() as tmpdir:
-            n2_relation = scenario.Relation(
+            n2_relation = testing.Relation(
                 endpoint="fiveg_n2",
                 interface="fiveg_n2",
                 remote_app_data={
@@ -356,28 +356,28 @@ class TestCharmConfigure(CUCharmFixtures):
                     "amf_ip_address": "1.2.3.4",
                 },
             )
-            f1_relation = scenario.Relation(
+            f1_relation = testing.Relation(
                 endpoint="fiveg_f1",
                 interface="fiveg_f1",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/tmp/conf",
                 source=tmpdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="cu",
                 mounts={"config": config_mount},
                 can_connect=True,
                 execs={
-                    scenario.Exec(
+                    testing.Exec(
                         command_prefix=["ip", "route", "show"],
                         stdout="192.168.252.0/24 via 192.168.251.1",
                         stderr="",
                     )
                 },
             )
-            state_in = scenario.State(
-                model=scenario.Model(name="whatever"),
+            state_in = testing.State(
+                model=testing.Model(name="whatever"),
                 config={"f1-ip-address": test_f1_ip_address, "f1-port": 3522},
                 leader=True,
                 containers=[container],
@@ -395,7 +395,7 @@ class TestCharmConfigure(CUCharmFixtures):
 
     def test_given_n3_route_not_created_when_config_changed_then_n3_route_is_created(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            n2_relation = scenario.Relation(
+            n2_relation = testing.Relation(
                 endpoint="fiveg_n2",
                 interface="fiveg_n2",
                 remote_app_data={
@@ -404,25 +404,25 @@ class TestCharmConfigure(CUCharmFixtures):
                     "amf_ip_address": "1.2.3.4",
                 },
             )
-            f1_relation = scenario.Relation(
+            f1_relation = testing.Relation(
                 endpoint="fiveg_f1",
                 interface="fiveg_f1",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/tmp/conf",
                 source=tmpdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="cu",
                 mounts={"config": config_mount},
                 can_connect=True,
                 execs={
-                    scenario.Exec(
+                    testing.Exec(
                         command_prefix=["ip", "route", "show"],
                         stdout="",
                         stderr="",
                     ),
-                    scenario.Exec(
+                    testing.Exec(
                         command_prefix=[
                             "ip",
                             "route",
@@ -436,8 +436,8 @@ class TestCharmConfigure(CUCharmFixtures):
                     ),
                 },
             )
-            state_in = scenario.State(
-                model=scenario.Model(name="whatever"),
+            state_in = testing.State(
+                model=testing.Model(name="whatever"),
                 leader=True,
                 containers=[container],
                 relations=[n2_relation, f1_relation],
@@ -458,7 +458,7 @@ class TestCharmConfigure(CUCharmFixtures):
 
     def test_given_n3_route_created_when_config_changed_then_n3_route_is_not_created(self, caplog):
         with tempfile.TemporaryDirectory() as tmpdir:
-            n2_relation = scenario.Relation(
+            n2_relation = testing.Relation(
                 endpoint="fiveg_n2",
                 interface="fiveg_n2",
                 remote_app_data={
@@ -467,28 +467,28 @@ class TestCharmConfigure(CUCharmFixtures):
                     "amf_ip_address": "1.2.3.4",
                 },
             )
-            f1_relation = scenario.Relation(
+            f1_relation = testing.Relation(
                 endpoint="fiveg_f1",
                 interface="fiveg_f1",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/tmp/conf",
                 source=tmpdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="cu",
                 mounts={"config": config_mount},
                 can_connect=True,
                 execs={
-                    scenario.Exec(
+                    testing.Exec(
                         command_prefix=["ip", "route", "show"],
                         stdout="192.168.252.0/24 via 192.168.251.1",
                         stderr="",
                     )
                 },
             )
-            state_in = scenario.State(
-                model=scenario.Model(name="whatever"),
+            state_in = testing.State(
+                model=testing.Model(name="whatever"),
                 leader=True,
                 containers=[container],
                 relations=[n2_relation, f1_relation],
@@ -498,7 +498,7 @@ class TestCharmConfigure(CUCharmFixtures):
 
             self.ctx.run(self.ctx.on.config_changed(), state_in)
 
-            # When scenario 7 is out, we should assert that the mock exec was called
+            # When testing 7 is out, we should assert that the mock exec was called
             # instead of validating log content
-            # Reference: https://github.com/canonical/ops-scenario/issues/180
+            # Reference: https://github.com/canonical/ops-testing/issues/180
             assert "N3 route created" not in caplog.text

--- a/tests/unit/test_charm_remove.py
+++ b/tests/unit/test_charm_remove.py
@@ -3,18 +3,18 @@
 # See LICENSE file for licensing details.
 
 
-import scenario
+from ops import testing
 
 from tests.unit.fixtures import CUCharmFixtures
 
 
 class TestCharmRemove(CUCharmFixtures):
     def test_given_unit_is_leader_when_remove_then_k8s_multus_is_removed(self):
-        container = scenario.Container(
+        container = testing.Container(
             name="cu",
             can_connect=False,
         )
-        state_in = scenario.State(leader=True, containers=[container])
+        state_in = testing.State(leader=True, containers=[container])
 
         self.ctx.run(self.ctx.on.remove(), state_in)
 


### PR DESCRIPTION
# Description

Now that scenario testing is built into ops we use ops.testing instead of directly calling scenario. Both have the same API. scenario still needs to be independently installed.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library