### PR TITLE
feat: add TICS analysis workflow

### DIFF
--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -7,6 +7,6 @@ on:
 jobs:
   update:
     name: Update Issue
-    uses: canonical/sdcore-github-workflows/.github/workflows/issues.yaml@v2.3.1
+    uses: canonical/sdcore-github-workflows/.github/workflows/issues.yaml@v2.3.2
     secrets:
       JIRA_URL: ${{ secrets.JIRA_URL }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,37 +13,37 @@ on:
 jobs:
   codeql:
     name: CodeQL Analysis
-    uses: canonical/sdcore-github-workflows/.github/workflows/codeql-analysis.yml@v2.3.1
+    uses: canonical/sdcore-github-workflows/.github/workflows/codeql-analysis.yml@v2.3.2
 
   check-libraries:
-    uses: canonical/sdcore-github-workflows/.github/workflows/check-libraries.yaml@v2.3.1
+    uses: canonical/sdcore-github-workflows/.github/workflows/check-libraries.yaml@v2.3.2
     secrets:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
 
   lint-report:
-    uses: canonical/sdcore-github-workflows/.github/workflows/lint-report.yaml@v2.3.1
+    uses: canonical/sdcore-github-workflows/.github/workflows/lint-report.yaml@v2.3.2
 
   terraform-check:
-    uses: canonical/sdcore-github-workflows/.github/workflows/terraform.yaml@v2.3.1
+    uses: canonical/sdcore-github-workflows/.github/workflows/terraform.yaml@v2.3.2
 
   static-analysis:
-    uses: canonical/sdcore-github-workflows/.github/workflows/static-analysis.yaml@v2.3.1
+    uses: canonical/sdcore-github-workflows/.github/workflows/static-analysis.yaml@v2.3.2
 
   unit-tests-with-coverage:
-    uses: canonical/sdcore-github-workflows/.github/workflows/unit-test.yaml@v2.3.1
+    uses: canonical/sdcore-github-workflows/.github/workflows/unit-test.yaml@v2.3.2
 
   build:
     needs:
       - lint-report
       - static-analysis
       - unit-tests-with-coverage
-    uses: canonical/sdcore-github-workflows/.github/workflows/build.yaml@v2.3.1
+    uses: canonical/sdcore-github-workflows/.github/workflows/build.yaml@v2.3.2
     secrets: inherit
 
   integration-test:
     needs:
       - build
-    uses: canonical/sdcore-github-workflows/.github/workflows/integration-test-with-multus.yaml@v2.3.1
+    uses: canonical/sdcore-github-workflows/.github/workflows/integration-test-with-multus.yaml@v2.3.2
 
   publish-charm:
     name: Publish Charm
@@ -53,7 +53,7 @@ jobs:
       - unit-tests-with-coverage
       - integration-test
     if: ${{ github.ref_name == 'main' }}
-    uses: canonical/sdcore-github-workflows/.github/workflows/publish-charm.yaml@v2.3.1
+    uses: canonical/sdcore-github-workflows/.github/workflows/publish-charm.yaml@v2.3.2
     with:
       track-name: 2.2
     secrets:
@@ -78,7 +78,7 @@ jobs:
       - publish-charm
       - fiveg-f1-lib-needs-publishing
     if: ${{ github.ref_name == 'main' }}
-    uses: canonical/sdcore-github-workflows/.github/workflows/publish-lib.yaml@v2.3.1
+    uses: canonical/sdcore-github-workflows/.github/workflows/publish-lib.yaml@v2.3.2
     with:
       lib-name: "charms.oai_ran_cu_k8s.v0.fiveg_f1"
     secrets:

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -22,7 +22,7 @@ on:
 jobs:
   promote:
     name: Promote Charm
-    uses: canonical/sdcore-github-workflows/.github/workflows/promote.yaml@v2.3.1
+    uses: canonical/sdcore-github-workflows/.github/workflows/promote.yaml@v2.3.2
     with:
       promotion: ${{ github.event.inputs.promotion }}
       track-name: ${{ github.event.inputs.track-name }}

--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -1,0 +1,14 @@
+name: TiCS Static Analysis
+
+on:
+  schedule:
+    - cron: '0 7 * * 0' # Every Sunday at 7 am
+  workflow_dispatch: # Allows manual triggering
+
+jobs:
+  tics-analysis:
+    uses: canonical/sdcore-github-workflows/.github/workflows/tics-scan.yaml@v2.3.2
+    with:
+      project: sdcore-amf-k8s-operator
+    secrets:
+      TICSAUTHTOKEN: ${{ secrets.TICSAUTHTOKEN }}

--- a/.github/workflows/update-libs.yaml
+++ b/.github/workflows/update-libs.yaml
@@ -11,5 +11,5 @@ permissions:
 jobs:
   update-lib:
     name: Check libraries
-    uses: canonical/sdcore-github-workflows/.github/workflows/update-libs.yaml@v2.3.1
+    uses: canonical/sdcore-github-workflows/.github/workflows/update-libs.yaml@v2.3.2
     secrets: inherit

--- a/tox.ini
+++ b/tox.ini
@@ -54,6 +54,7 @@ description = Run unit tests
 commands =
     coverage run --source={[vars]src_path},{[vars]lib_path} -m pytest {[vars]unit_test_path} -v --tb native -s {posargs}
     coverage report
+    coverage xml
 
 [testenv:integration]
 description = Run integration tests


### PR DESCRIPTION
# Description

Adds a TiCS static analysis workflow to run every week, which is the maximum frequency recommend.
The manual trigger option allows developers to manually trigger the analysis workflow whenever needed.
Besides, this PR adds coverage.xml as an outcome of unit tests as this file is required for TiCS static analysis.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library