### PR TITLE
chore: add validation for gNB name in relation databag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 *.charm
 .tox/
 .coverage
+coverage.xml
 __pycache__/
 *.py[cod]
 .idea

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -131,7 +131,9 @@ class TestCharmConfigure(CUCharmFixtures):
                 },
             )
             core_gnb_relation = testing.Relation(
-                endpoint="fiveg_core_gnb", interface="fiveg_core_gnb"
+                endpoint="fiveg_core_gnb",
+                interface="fiveg_core_gnb",
+                local_app_data={"gnb-name": "ran-cu-name"},
             )
             config_mount = testing.Mount(
                 location="/tmp/conf",
@@ -233,7 +235,9 @@ class TestCharmConfigure(CUCharmFixtures):
                 },
             )
             core_gnb_relation = testing.Relation(
-                endpoint="fiveg_core_gnb", interface="fiveg_core_gnb"
+                endpoint="fiveg_core_gnb",
+                interface="fiveg_core_gnb",
+                local_app_data={"gnb-name": "ran-cu-name"},
             )
             config_mount = testing.Mount(
                 location="/tmp/conf",


### PR DESCRIPTION
# Description

This PR adds the check for the presence of `gnb-name` in the local databag for the `fiveg_core_gnb` relation. If the gNB name is not published, the charm remains in `Blocked` status.
This PR is necessary after [this improvement](https://github.com/canonical/sdcore-nms-k8s-operator/pull/464), as the gNB  name may not pass the validation and therefore not be published in the library (and then added to NMS).

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library