### PR TITLE
feat: Add host-device CNI support

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -52,13 +52,13 @@ config:
       default: bridge
       description: |
         Multus CNI plugin to use for the interfaces.
-        Allowed values are `bridge`, `macvlan`.
+        Allowed values are `bridge`, `macvlan` and `host-device`.
     f1-interface-name:
       type: string
       default: "f1"
       description: |
         Host interface to use for the F1 communication with the DU.
-        With the `macvlan` CNI, the corresponding macvlan interface needs to exist on the host.
+        With the `macvlan` or `host-device` CNIs, the corresponding interface needs to exist on the host.
     f1-ip-address:
       type: string
       default: "192.168.254.7/24"
@@ -72,7 +72,7 @@ config:
       default: "n3"
       description: | 
         Host interface to use for the N3 communication with the UPF.
-        With the `macvlan` CNI, the corresponding macvlan interface needs to exist on the host.
+        With the `macvlan` or `host-device` CNIs, the corresponding interface needs to exist on the host.
     n3-ip-address:
       type: string
       default: "192.168.251.6/24"

--- a/src/charm.py
+++ b/src/charm.py
@@ -318,18 +318,18 @@ class OAIRANCUOperator(CharmBase):
             f"{self._charm_config.f1_interface_name}-br",
         )
 
-    def _add_cni_type_to_nad_config(
-        self, nad_config: dict, master_interface: str, bridge: str
-    ) -> dict:
+    def _add_cni_type_to_nad_config(self, nad_config: dict, interface: str, bridge: str) -> dict:
         if self._charm_config.cni_type == CNIType.macvlan:
             nad_config.update(
                 {
                     "type": "macvlan",
-                    "master": master_interface,
+                    "master": interface,
                 }
             )
         elif self._charm_config.cni_type == CNIType.bridge:
             nad_config.update({"type": "bridge", "bridge": bridge})
+        elif self._charm_config.cni_type == CNIType.host_device:
+            nad_config.update({"type": "host-device", "device": interface})
         return nad_config
 
     def _network_attachment_definitions_from_config(self) -> list[NetworkAttachmentDefinition]:

--- a/src/charm_config.py
+++ b/src/charm_config.py
@@ -41,6 +41,7 @@ class CNIType(str, Enum):
 
     bridge = "bridge"
     macvlan = "macvlan"
+    host_device = "host-device"
 
 
 def to_kebab(name: str) -> str:


### PR DESCRIPTION
# Description

This adds support for using the `host-device` CNI to directly pass interfaces to the container.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library